### PR TITLE
feat(perplexity): add search_domain_filter in RequestOptions

### DIFF
--- a/llms/aistudio/aistudio.go
+++ b/llms/aistudio/aistudio.go
@@ -261,8 +261,8 @@ func (p *AiStudio) adaptResponse(llm internal.Adapter, response *genai.GenerateC
 		if candidate.GroundingMetadata != nil {
 			grounding = &llmadapter.ResponseGrounding{
 				Searches: candidate.GroundingMetadata.WebSearchQueries,
-				Sources: lo.Map(candidate.GroundingMetadata.GroundingChunks, func(c *genai.GroundingChunk, _ int) llmadapter.ResponseGroudingSource {
-					return llmadapter.ResponseGroudingSource{
+				Sources: lo.Map(candidate.GroundingMetadata.GroundingChunks, func(c *genai.GroundingChunk, _ int) llmadapter.ResponseGroundingSource {
+					return llmadapter.ResponseGroundingSource{
 						Domain: lo.CoalesceOrEmpty(c.Web.Domain, c.Web.Title),
 						Url:    c.Web.URI,
 					}

--- a/llms/perplexity/perplexity.go
+++ b/llms/perplexity/perplexity.go
@@ -1,13 +1,16 @@
 package perplexity
 
 import (
+	"encoding/json"
 	"reflect"
+	"time"
 
 	llmadapter "github.com/checkmarble/llm-adapter"
 	"github.com/checkmarble/llm-adapter/internal"
 	base "github.com/checkmarble/llm-adapter/llms/openai"
 	"github.com/fatih/structs"
 	"github.com/openai/openai-go"
+	"github.com/samber/lo"
 )
 
 type Perplexity struct {
@@ -36,6 +39,7 @@ func New(openAiOpts ...base.Opt) (*Perplexity, error) {
 	}
 
 	llm.RequestHookFunc = llm.transformRequest
+	llm.ResponseHookFunc = llm.transformResponse
 
 	return &llm, nil
 }
@@ -44,6 +48,41 @@ func (p *Perplexity) transformRequest(requester llmadapter.Requester, cfg *opena
 	opts := internal.CastProviderOptions[RequestOptions](requester.ProviderRequestOptions(p))
 
 	cfg.SetExtraFields(structs.Map(opts))
+
+	return nil
+}
+
+func (p *Perplexity) transformResponse(response *openai.ChatCompletion, resp *llmadapter.InnerResponse) error {
+	searchResultsField, ok := response.JSON.ExtraFields["search_results"]
+	if !ok {
+		return nil
+	}
+
+	searchResultsContent := searchResultsField.Raw()
+
+	searchResults := []SearchResult{}
+
+	if err := json.Unmarshal([]byte(searchResultsContent), &searchResults); err != nil {
+		return err
+	}
+
+	// Loop thought all candidates
+	// Perplexity returns only one candidate, the search results are linked to this candidate
+	// Use loop to avoid dealing with checking if there is a candidate or not
+	for i := range resp.Candidates {
+		grouding := llmadapter.ResponseGrounding{
+			Sources: lo.Map(searchResults, func(result SearchResult, _ int) llmadapter.ResponseGroudingSource {
+				date, _ := time.Parse(time.DateOnly, result.Date)
+
+				return llmadapter.ResponseGroudingSource{
+					Title: result.Title,
+					Url:   result.URL,
+					Date:  date,
+				}
+			}),
+		}
+		resp.Candidates[i].Grounding = &grouding
+	}
 
 	return nil
 }

--- a/llms/perplexity/perplexity.go
+++ b/llms/perplexity/perplexity.go
@@ -70,18 +70,18 @@ func (p *Perplexity) transformResponse(response *openai.ChatCompletion, resp *ll
 	// Perplexity returns only one candidate, the search results are linked to this candidate
 	// Use loop to avoid dealing with checking if there is a candidate or not
 	for i := range resp.Candidates {
-		grouding := llmadapter.ResponseGrounding{
-			Sources: lo.Map(searchResults, func(result SearchResult, _ int) llmadapter.ResponseGroudingSource {
+		grounding := llmadapter.ResponseGrounding{
+			Sources: lo.Map(searchResults, func(result SearchResult, _ int) llmadapter.ResponseGroundingSource {
 				date, _ := time.Parse(time.DateOnly, result.Date)
 
-				return llmadapter.ResponseGroudingSource{
+				return llmadapter.ResponseGroundingSource{
 					Title: result.Title,
 					Url:   result.URL,
 					Date:  date,
 				}
 			}),
 		}
-		resp.Candidates[i].Grounding = &grouding
+		resp.Candidates[i].Grounding = &grounding
 	}
 
 	return nil

--- a/llms/perplexity/perplexity_test.go
+++ b/llms/perplexity/perplexity_test.go
@@ -26,6 +26,7 @@ func TestPerplexityExtras(t *testing.T) {
 			WebSearch: WebSearch{
 				UserLocation: UserLocation{Country: "FR"},
 			},
+			SearchDomainFilter: []string{"google.com", "wikipedia.org"},
 		})
 
 	gock.New("https://api.perplexity.ai").
@@ -34,11 +35,13 @@ func TestPerplexityExtras(t *testing.T) {
 		AddMatcher(func(req *http.Request, _ *gock.Request) (bool, error) {
 			body, _ := io.ReadAll(req.Body)
 
-			assert.Len(t, gjson.GetBytes(body, "@this").Map(), 4) // Always includes `messages`.
+			assert.Len(t, gjson.GetBytes(body, "@this").Map(), 5) // Always includes `messages`.
 			assert.Equal(t, "academic", gjson.GetBytes(body, "search_mode").String())
 			assert.Equal(t, "7/1/2025", gjson.GetBytes(body, "search_before_date_filter").String())
 			assert.Equal(t, "FR", gjson.GetBytes(body, "web_search_options.user_location.country").String())
-
+			assert.Len(t, gjson.GetBytes(body, "search_domain_filter").Array(), 2)
+			assert.Equal(t, "google.com", gjson.GetBytes(body, "search_domain_filter").Array()[0].String())
+			assert.Equal(t, "wikipedia.org", gjson.GetBytes(body, "search_domain_filter").Array()[1].String())
 			return true, nil
 		}).
 		Reply(http.StatusOK).

--- a/llms/perplexity/request_options.go
+++ b/llms/perplexity/request_options.go
@@ -22,13 +22,14 @@ const (
 )
 
 type RequestOptions struct {
-	SearchMode        SearchMode `structs:"search_mode,omitempty"`
-	SearchRecency     string     `structs:"search_recency_filter,omitempty"`
-	BeforeDate        date       `structs:"search_before_date_filter,string,omitempty"`
-	AfterDate         date       `structs:"search_after_date_filter,string,omitempty"`
-	LastUpdatedBefore date       `structs:"last_updated_before_filter,string,omitempty"`
-	LastUpdatedAfter  date       `structs:"last_updated_after_filter,string,omitempty"`
-	WebSearch         WebSearch  `structs:"web_search_options,omitempty"`
+	SearchMode         SearchMode `structs:"search_mode,omitempty"`
+	SearchRecency      string     `structs:"search_recency_filter,omitempty"`
+	BeforeDate         date       `structs:"search_before_date_filter,string,omitempty"`
+	AfterDate          date       `structs:"search_after_date_filter,string,omitempty"`
+	LastUpdatedBefore  date       `structs:"last_updated_before_filter,string,omitempty"`
+	LastUpdatedAfter   date       `structs:"last_updated_after_filter,string,omitempty"`
+	SearchDomainFilter []string   `structs:"search_domain_filter,omitempty"`
+	WebSearch          WebSearch  `structs:"web_search_options,omitempty"`
 }
 
 type WebSearch struct {

--- a/llms/perplexity/response.go
+++ b/llms/perplexity/response.go
@@ -1,0 +1,8 @@
+package perplexity
+
+type SearchResult struct {
+	Title       string `json:"title"`
+	URL         string `json:"url"`
+	Date        string `json:"date"`
+	LastUpdated string `json:"last_updated"`
+}

--- a/request.go
+++ b/request.go
@@ -91,7 +91,7 @@ type innerRequest struct {
 // which candidate it responds to, in order to link tool responses to their
 // corresponding tool calls.
 //
-// It is generic in T which it will use to unmarshal the reponse into a typed
+// It is generic in T which it will use to unmarshal the response into a typed
 // struct.
 type Request[T any] struct {
 	innerRequest
@@ -421,7 +421,7 @@ func (r Request[T]) withToolResponse(tool ResponseToolCall, parts string) Reques
 // It will also take care of adding the matching tool definitions to the
 // Request, so there is not need to also call `WithTool`.
 //
-// Note that this requires that a candidate from the previous reponse was
+// Note that this requires that a candidate from the previous response was
 // selected by calling `FromCandidate()` before this function, to determine
 // which function the provider asked to be called.
 func (r Request[T]) WithToolExecution(tools ...internal.Tool) Request[T] {
@@ -458,7 +458,7 @@ func (r Request[T]) WithToolExecution(tools ...internal.Tool) Request[T] {
 	return r
 }
 
-// WithProviderOptions set provier-specific options.
+// WithProviderOptions set provider-specific options.
 //
 // Some options are not going to be supported by all providers, so they will
 // usually defined a type representing options specific to them. This function

--- a/response.go
+++ b/response.go
@@ -53,8 +53,10 @@ type ResponseGrounding struct {
 }
 
 type ResponseGroudingSource struct {
+	Title  string
 	Domain string
 	Url    string
+	Date   time.Time
 }
 
 // ResponseToolCall is a request from a provider to execute a tool.

--- a/response.go
+++ b/response.go
@@ -48,11 +48,11 @@ type ResponseCandidate struct {
 
 type ResponseGrounding struct {
 	Searches []string
-	Sources  []ResponseGroudingSource
+	Sources  []ResponseGroundingSource
 	Snippets []string
 }
 
-type ResponseGroudingSource struct {
+type ResponseGroundingSource struct {
 	Title  string
 	Domain string
 	Url    string
@@ -104,7 +104,7 @@ func (r Response[T]) Thread() *ThreadId {
 
 // Get will return the deserialized output for a candidate.
 //
-// It will parse the reponse and deserialize it to the requested type, or return
+// It will parse the response and deserialize it to the requested type, or return
 // an error if it cannot.
 func (r Response[T]) Get(idx int) (T, error) {
 	if idx > len(r.Candidates)-1 {

--- a/serializer.go
+++ b/serializer.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	// Serializers is a global object that hold singleton of library-provided
+	// Serializers is a global object that holds singleton of library-provided
 	// serializers
 	Serializers = struct {
 		Json jsonSerializer

--- a/threads.go
+++ b/threads.go
@@ -7,7 +7,7 @@ func (*noCopy) Unlock() {}
 
 // ThreadId uniquely represents a conversation with an LLM.
 //
-// It is used to mark and identity a specific conversation and accumulate its
+// It is used to mark and identify a specific conversation and accumulate its
 // history. ThreadsId inherent identifiers (their memory address is the
 // identifier), so their value cannot be copied, only pointers should be passed
 // around.


### PR DESCRIPTION
Add a `search_domain_filter` option to RequestOptions to filter by domain, allowing Perplexity to include or exclude specific domains or URLs.

Introduce a new `ResponseHookFunc` in `openAI` to transform responses based on the OpenAI response object. This enables parsing OpenAI extra fields into a Perplexity search result object and populating the Grounding object.